### PR TITLE
Change urllib3 version to 1.25.11

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -35,4 +35,4 @@ sqlparse==0.3.1
 static3==0.7.0
 Unipath==1.1
 uritemplate==3.0.1
-urllib3==1.26.5
+urllib3==1.25.11


### PR DESCRIPTION
Description: There is a conflicting dependencies error.

```
The conflict is caused by:
    The user requested urllib3==1.26.5
    requests 2.23.0 depends on urllib3!=1.25.0, !=1.25.1, <1.26 and >=1.21.1
```

I removed the urllib3 dependency. pip resolved the conflict and automatically
installed 1.25.11 version. Updating the urllib3 version in requirements
to match.

Test Plan: installation succeeds